### PR TITLE
Fix improper assignment to path installation.mdx

### DIFF
--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -59,7 +59,7 @@ You can follow the installation instructions in the
       environment variable.
 
       ```sh title=".zshrc"
-      export PATH="$PATH:/home/user/.pesde/bin"
+      export PATH="$PATH:/$HOME/.pesde/bin"
       ```
 
       You should then be able to run `pesde` after restarting your shell.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -59,7 +59,7 @@ You can follow the installation instructions in the
       environment variable.
 
       ```sh title=".zshrc"
-      export PATH = "$PATH:/home/user/.pesde/bin"
+      export PATH="$PATH:/home/user/.pesde/bin"
       ```
 
       You should then be able to run `pesde` after restarting your shell.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -59,7 +59,7 @@ You can follow the installation instructions in the
       environment variable.
 
       ```sh title=".zshrc"
-      export PATH="$PATH:/$HOME/.pesde/bin"
+      export PATH="$PATH:$HOME/.pesde/bin"
       ```
 
       You should then be able to run `pesde` after restarting your shell.


### PR DESCRIPTION
Hi, noticed a small error in the installation instructions. There shouldn't be spaces around the equals 