### PR TITLE
Update quickstart.mdx - Typo

### DIFF
--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -111,7 +111,7 @@ pesde install
 ```
 
 You should see that pesde has created a `luau_packages` folder containing the
-newly installed package. It has alsoo created a `pesde.lock` file, this file
+newly installed package. It has also created a `pesde.lock` file, this file
 contains the exact versions of the dependencies that were installed so that
 they can be installed again in the future.
 


### PR DESCRIPTION
## Fixed a typo
Removed one trailing ‘o’


> _Pesde_ contributor 😎