### PR TITLE
Include debug builds action

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -24,7 +24,7 @@ jobs:
         id: trim_sha
         run: |
           commit_sha=${{ github.sha }}
-          echo "trimmed_sha=${commit_sha:0:7}" | tee $GITHUB_ENV
+          echo "trimmed_sha=${commit_sha:0:7}" | tee $GITHUB_OUTPUT
   build:
     strategy:
       matrix:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -7,12 +7,21 @@ on:
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: v${{ steps.get_version.outputs.value }}+rev.g${{ steps.trim_sha.outputs.trimmed_sha }}
     steps:
+      - name: Get package version
+        uses: SebRollen/toml-action@v1.2.0
+        id: get_version
+        with:
+          file: Cargo.toml
+          field: package.version
+
       - name: Trim commit SHA
         id: trim_sha
         run: |
           commit_sha=${{ github.sha }}
-          echo "trimmed_sha=r${commit_sha:0:7}" | tee $GITHUB_ENV
+          echo "trimmed_sha=${commit_sha:0:7}" | tee $GITHUB_ENV
   build:
     strategy:
       matrix:
@@ -20,22 +29,22 @@ jobs:
           - job-name: Windows x86_64
             target: x86_64-pc-windows-msvc
             runs-on: windows-latest
-            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-windows-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-windows-x86_64
 
           - job-name: Linux x86_64
             target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
-            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-linux-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-linux-x86_64
 
           - job-name: macOS x86_64
             target: x86_64-apple-darwin
             runs-on: macos-13
-            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-macos-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-macos-x86_64
 
           - job-name: macOS aarch64
             target: aarch64-apple-darwin
             runs-on: macos-latest
-            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-macos-aarch64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-macos-aarch64
 
     name: Build for ${{ matrix.job-name }}
     runs-on: ${{ matrix.runs-on }}
@@ -43,15 +52,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
     - name: Install Linux build dependencies
       if: ${{ matrix.runs-on == 'ubuntu-latest' }}
       run: |
         sudo apt-get update
         sudo apt-get install libdbus-1-dev pkg-config
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+
     - name: Compile in debug mode
       run: cargo build --bins --no-default-features --features bin,patches,wally-compat --target ${{ matrix.target }} --locked
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - name: Trim commit SHA
         id: trim_sha
-        run: echo "trimmed_sha=${{ github.sha:0:7 }}" >> $GITHUB_ENV
+        run: |
+          commit_sha=${{ github.sha }}
+          echo "trimmed_sha=${commit_sha:0:7}" >> $GITHUB_ENV
   build:
     strategy:
       matrix:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -19,32 +19,33 @@ jobs:
             runs-on: ubuntu-latest
             artifact-name: pesde-debug-${{ github.sha }}-linux-x86_64
 
-          - job-name: Linux aarch64
-            target: aarch64-unknown-linux-gnu
-            runs-on: ubuntu-latest
-            artifact-name: pesde-debug-${{ github.sha }}-linux-aarch64
-
           - job-name: macOS x86_64
             target: x86_64-apple-darwin
-            runs-on: macos-latest
+            runs-on: macos-13
             artifact-name: pesde-debug-${{ github.sha }}-macos-x86_64
 
           - job-name: macOS aarch64
             target: aarch64-apple-darwin
             runs-on: macos-latest
             artifact-name: pesde-debug-${{ github.sha }}-macos-aarch64
+
     name: Build for ${{ matrix.job-name }}
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install Linux build dependencies
+      if: ${{ matrix.runs-on == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install libdbus-1-dev pkg-config
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
     - name: Compile in debug mode
-      run: cargo build --target ${{ matrix.target }}
+      run: cargo build --bins --all-features --exclude-features version-management --target ${{ matrix.target }} --locked
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact-name }}
         path: target/${{ matrix.target }}/debug/pesde*

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trim commit SHA
+        id: trim_sha
+        run: echo "trimmed_sha='r$(echo ${{ github.sha }} | cut -c1-7)'" >> $GITHUB_ENV
   build:
     strategy:
       matrix:
@@ -12,26 +18,26 @@ jobs:
           - job-name: Windows x86_64
             target: x86_64-pc-windows-msvc
             runs-on: windows-latest
-            artifact-name: pesde-debug-${{ github.sha }}-windows-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-windows-x86_64
 
           - job-name: Linux x86_64
             target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
-            artifact-name: pesde-debug-${{ github.sha }}-linux-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-linux-x86_64
 
           - job-name: macOS x86_64
             target: x86_64-apple-darwin
             runs-on: macos-13
-            artifact-name: pesde-debug-${{ github.sha }}-macos-x86_64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-macos-x86_64
 
           - job-name: macOS aarch64
             target: aarch64-apple-darwin
             runs-on: macos-latest
-            artifact-name: pesde-debug-${{ github.sha }}-macos-aarch64
+            artifact-name: pesde-debug-${{ needs.get-version.outputs.trimmed_sha }}-macos-aarch64
 
     name: Build for ${{ matrix.job-name }}
     runs-on: ${{ matrix.runs-on }}
-
+    needs: get-version
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   get-version:
+    name: Get build version
     runs-on: ubuntu-latest
     outputs:
       version: v${{ steps.get_version.outputs.value }}+rev.g${{ steps.trim_sha.outputs.trimmed_sha }}

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,6 +10,9 @@ jobs:
     outputs:
       version: v${{ steps.get_version.outputs.value }}+rev.g${{ steps.trim_sha.outputs.trimmed_sha }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
       - name: Get package version
         uses: SebRollen/toml-action@v1.2.0
         id: get_version

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -30,22 +30,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - job-name: Windows x86_64
+          - job-name: windows-x86_64
             target: x86_64-pc-windows-msvc
             runs-on: windows-latest
             artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-windows-x86_64
 
-          - job-name: Linux x86_64
+          - job-name: linux-x86_64
             target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
             artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-linux-x86_64
 
-          - job-name: macOS x86_64
+          - job-name: macos-x86_64
             target: x86_64-apple-darwin
             runs-on: macos-13
             artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-macos-x86_64
 
-          - job-name: macOS aarch64
+          - job-name: macos-aarch64
             target: aarch64-apple-darwin
             runs-on: macos-latest
             artifact-name: pesde-debug-${{ needs.get-version.outputs.version }}-macos-aarch64

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,50 @@
+name: Debug
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - job-name: Windows x86_64
+            target: x86_64-pc-windows-msvc
+            runs-on: windows-latest
+            artifact-name: pesde-debug-${{ github.sha }}-windows-x86_64
+
+          - job-name: Linux x86_64
+            target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+            artifact-name: pesde-debug-${{ github.sha }}-linux-x86_64
+
+          - job-name: Linux aarch64
+            target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+            artifact-name: pesde-debug-${{ github.sha }}-linux-aarch64
+
+          - job-name: macOS x86_64
+            target: x86_64-apple-darwin
+            runs-on: macos-latest
+            artifact-name: pesde-debug-${{ github.sha }}-macos-x86_64
+
+          - job-name: macOS aarch64
+            target: aarch64-apple-darwin
+            runs-on: macos-latest
+            artifact-name: pesde-debug-${{ github.sha }}-macos-aarch64
+    name: Build for ${{ matrix.job-name }}
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Compile in debug mode
+      run: cargo build --target ${{ matrix.target }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.artifact-name }}
+        path: target/${{ matrix.target }}/debug/pesde*

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
     - name: Compile in debug mode
-      run: cargo build --bins --all-features --exclude-features version-management --target ${{ matrix.target }} --locked
+      run: cargo build --bins --no-default-features --features bin,patches,wally-compat --target ${{ matrix.target }} --locked
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -12,7 +12,7 @@ jobs:
         id: trim_sha
         run: |
           commit_sha=${{ github.sha }}
-          echo "trimmed_sha=${commit_sha:0:7}" >> $GITHUB_ENV
+          echo "trimmed_sha=r${commit_sha:0:7}" | tee $GITHUB_ENV
   build:
     strategy:
       matrix:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -73,4 +73,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact-name }}
-        path: target/${{ matrix.target }}/debug/pesde*
+        if-no-files-found: error
+        path: |
+          target/${{ matrix.target }}/debug/pesde.exe
+          target/${{ matrix.target }}/debug/pesde

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Trim commit SHA
         id: trim_sha
-        run: echo "trimmed_sha='r$(echo ${{ github.sha }} | cut -c1-7)'" >> $GITHUB_ENV
+        run: echo "trimmed_sha=${{ github.sha:0:7 }}" >> $GITHUB_ENV
   build:
     strategy:
       matrix:


### PR DESCRIPTION
This PR implements a GitHub action workflow which creates debug builds for pesde on pull requests and commits, which compiles with debug mode on. 

This is a required prerequisite for us to move to less verbose logging on release builds (enabling verbose logging only on debug builds), which was introduced in the recent migration to `tracing`. 

It would also be a good idea to setup issue templates on GitHub which tell users to use a debug build with `RUST_LOG` set and include those logs as a part of the issue.