### PR TITLE
Add an aside for symlink errors on Windows

### DIFF
--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -40,6 +40,17 @@ You can follow the installation instructions in the
 
       pesde should now be installed on your system. You may need to restart your
       computer for the changes to take effect.
+      
+      [dev-mode-guide]: https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
+
+      <Aside type="caution" title="Warning">
+      pesde uses symlinks which are an administrator-level operation on Windows.
+      To ensure proper functionality, enable [Developer Mode][dev-mode-guide].<br/><br/>
+      If you are getting errors such as <strong>'Failed to symlink file, a required privilege is not held by the client'</strong>, then enabling this setting will fix them.
+      </Aside>
+
+
+      
 
       </TabItem>
       <TabItem label="Linux & macOS">
@@ -77,7 +88,7 @@ You can follow the installation instructions in the
 
 </Steps>
 
-<Aside type="caution">
+<Aside type="caution" title="Warning">
 
 It is not recommended to use toolchain managers (such as Rokit or Aftman) to
 install pesde. You can use `pesde self-upgrade` if you need to update pesde.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -48,7 +48,7 @@ You can follow the installation instructions in the
       To ensure proper functionality, enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).
       
       
-      If you are getting errors such as <strong>'Failed to symlink file, a required privilege is not held by the client'</strong>, then enabling this setting will fix them.
+      If you are getting errors such as `'Failed to symlink file, a required privilege is not held by the client'`, then enabling this setting will fix them.
       </Aside>
 
       </TabItem>

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -43,7 +43,7 @@ You can follow the installation instructions in the
 
       [dev-mode-guide]: https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
 
-      <Aside type="caution" title="Warning">
+      <Aside type="caution">
       pesde uses symlinks which are an administrator-level operation on Windows.
       To ensure proper functionality, enable [Developer Mode][dev-mode-guide].<br/><br/>
       If you are getting errors such as <strong>'Failed to symlink file, a required privilege is not held by the client'</strong>, then enabling this setting will fix them.
@@ -85,7 +85,7 @@ You can follow the installation instructions in the
 
 </Steps>
 
-<Aside type="caution" title="Warning">
+<Aside type="caution">
 
 It is not recommended to use toolchain managers (such as Rokit or Aftman) to
 install pesde. You can use `pesde self-upgrade` if you need to update pesde.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -40,7 +40,7 @@ You can follow the installation instructions in the
 
       pesde should now be installed on your system. You may need to restart your
       computer for the changes to take effect.
-      
+
       [dev-mode-guide]: https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
 
       <Aside type="caution" title="Warning">
@@ -48,9 +48,6 @@ You can follow the installation instructions in the
       To ensure proper functionality, enable [Developer Mode][dev-mode-guide].<br/><br/>
       If you are getting errors such as <strong>'Failed to symlink file, a required privilege is not held by the client'</strong>, then enabling this setting will fix them.
       </Aside>
-
-
-      
 
       </TabItem>
       <TabItem label="Linux & macOS">

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -46,7 +46,9 @@ You can follow the installation instructions in the
       To ensure proper functionality, enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).
       
       
-      If you are getting errors such as `'Failed to symlink file, a required privilege is not held by the client'`, then enabling this setting will fix them.
+      If you are getting errors such as `Failed to symlink file, a required
+      privilege is not held by the client`, then enabling this setting will fix
+      them.
       </Aside>
 
       </TabItem>

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -41,8 +41,6 @@ You can follow the installation instructions in the
       pesde should now be installed on your system. You may need to restart your
       computer for the changes to take effect.
 
-      [dev-mode-guide]: https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
-
       <Aside type="caution">
       pesde uses symlinks which are an administrator-level operation on Windows.
       To ensure proper functionality, enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).


### PR DESCRIPTION
When I was installing workspace dependencies, I was running into issues where pesde could not create symlinks. The error was as follows:

![image](https://github.com/user-attachments/assets/c79fb692-5c31-485c-9ccc-647de55bb7ba)

As discussed with @daimond113, this was due to the fact that windows limits the creation of symlinks by default and treats it as an administrator level operation:

![image](https://github.com/user-attachments/assets/53ef103a-c324-4120-98d5-7810e3fd5266)

I've added an admonition / aside to the docs (specifically the Windows section of the installation guide) such that people ensure to enable Windows' developer mode to mitigate this error.

![image](https://github.com/user-attachments/assets/39456d91-7f65-4a32-a954-e7c943d03967)

I also changed the title of the toolchain managers warning to make sure the two admonitions on the installation page were consistent in title.