### PR TITLE
refactor: use ffc rather than index

### DIFF
--- a/src/linking/generator.rs
+++ b/src/linking/generator.rs
@@ -171,7 +171,7 @@ pub fn get_lib_require_path(
 					let str = part.to_string_lossy();
 
 					Some(format!(
-						"[{:?}]",
+						":FindFirstChild({:?})",
 						if next_comp.is_some() {
 							&str
 						} else {


### PR DESCRIPTION
~~For `roblox_*_packages`, the current behaviour for the require path is `require(script.Parent[...])`. However, this PR converts that to the new format with a string path. As a result, luau-lsp now supports pesde again!~~

use `FindFirstChild` for paths instead of direct indexing to allow stuff like indexing reserved keywords, e.g. `Parent` and `script`.