### PR TITLE
fix: make repeated local dependencies installs idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Save GitHub OAuth token for engine downloads by @taoshotaro
 
+### Fixed
+- Make repeated local dependency installs idempotent by @taoshotaro
+
 ### Changed
 - Use FindFirstChild over direct indexing in dependency linkers by @Stefanuk12
 - Apply patches before ever executing scripts by @daimond113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Save GitHub OAuth token for engine downloads by @taoshotaro
 
-### Fixed
-- Make repeated local dependency installs idempotent by @taoshotaro
-
 ### Changed
 - Use FindFirstChild over direct indexing in dependency linkers by @Stefanuk12
 - Apply patches before ever executing scripts by @daimond113
+
+### Fixed
+- Make repeated local dependency installs idempotent by @taoshotaro
 
 ## [0.7.0-rc.6] - 2025-06-23
 ### Fixed

--- a/src/source/fs.rs
+++ b/src/source/fs.rs
@@ -239,13 +239,6 @@ impl PackageFs {
 		cas_path: Q,
 		link: bool,
 	) -> std::io::Result<()> {
-		// Clean up existing destination to make operation idempotent
-		match fs::remove_dir_all(destination.as_ref()).await {
-			Ok(_) => {}
-			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-			Err(e) => return Err(e),
-		}
-
 		match self {
 			PackageFs::Cas(entries) => {
 				package_fs_cas(

--- a/src/source/fs.rs
+++ b/src/source/fs.rs
@@ -221,6 +221,13 @@ impl PackageFs {
 		cas_path: Q,
 		link: bool,
 	) -> std::io::Result<()> {
+		// Clean up existing destination to make operation idempotent
+		match fs::remove_dir_all(destination.as_ref()).await {
+			Ok(_) => {}
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+			Err(e) => return Err(e),
+		}
+
 		match self {
 			PackageFs::Cas(entries) => {
 				package_fs_cas(


### PR DESCRIPTION
## Summary
* Fixed "File exists" errors on repeated installs for local dependencies
* Made `write_to` operations idempotent by clearing destination before writing

## Test
- [x] Test on GitHub Codespaces (Linux) and macOS
- [x] Test on Windows
