### PR TITLE
remove `init.luau`/`init.lua` from paths when generating link code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Do not generate init.lua(u) elements in require paths by @4x8Matrix
+
 ## [0.7.0-rc.7] - 2025-07-26
 ### Added
 - Save GitHub OAuth token for engine downloads by @taoshotaro

--- a/src/linking/generator.rs
+++ b/src/linking/generator.rs
@@ -92,20 +92,25 @@ fn luau_style_path(path: &Path) -> String {
 		.filter_map(|(ct, next_ct)| match ct {
 			Component::CurDir => Some(".".to_string()),
 			Component::ParentDir => Some("..".to_string()),
-			Component::Normal(part) => {
-				let str = part.to_string_lossy();
+			Component::Normal(part_os) => {
+                let part = part_os.to_string_lossy();
 
-				Some(
-					(if next_ct.is_some() {
-						&str
-					} else {
-						str.strip_suffix(".luau")
-							.or_else(|| str.strip_suffix(".lua"))
-							.unwrap_or(&str)
-					})
-					.to_string(),
-				)
-			}
+                if part == "init.lua" || part == "init.luau" {
+                    return None;
+                }
+
+                let displayed =
+                    if next_ct.is_some() {
+                        &part
+                    } else {
+                        part.strip_suffix(".luau")
+                            .or_else(|| part.strip_suffix(".lua"))
+                            .unwrap_or(&*part)
+                    }
+                    .to_string();
+
+                Some(displayed)
+            }
 			_ => None,
 		})
 		.collect::<Vec<_>>()

--- a/src/linking/generator.rs
+++ b/src/linking/generator.rs
@@ -92,24 +92,22 @@ fn luau_style_path(path: &Path) -> String {
 		.filter_map(|(ct, next_ct)| match ct {
 			Component::CurDir => Some(".".to_string()),
 			Component::ParentDir => Some("..".to_string()),
-			Component::Normal(part_os) => {
-				let part = part_os.to_string_lossy();
-
-				if part == "init.lua" || part == "init.luau" {
+			Component::Normal(part) => {
+				let str = part.to_string_lossy();
+				if str == "init.lua" || str == "init.luau" {
 					return None;
 				}
 
-				let displayed =
-					if next_ct.is_some() {
-						&part
+				Some(
+					(if next_ct.is_some() {
+						&str
 					} else {
-						part.strip_suffix(".luau")
-							.or_else(|| part.strip_suffix(".lua"))
-							.unwrap_or(&*part)
-					}
-					.to_string();
-
-				Some(displayed)
+						str.strip_suffix(".luau")
+							.or_else(|| str.strip_suffix(".lua"))
+							.unwrap_or(&str)
+					})
+					.to_string(),
+				)
 			}
 			_ => None,
 		})

--- a/src/linking/generator.rs
+++ b/src/linking/generator.rs
@@ -93,24 +93,24 @@ fn luau_style_path(path: &Path) -> String {
 			Component::CurDir => Some(".".to_string()),
 			Component::ParentDir => Some("..".to_string()),
 			Component::Normal(part_os) => {
-                let part = part_os.to_string_lossy();
+				let part = part_os.to_string_lossy();
 
-                if part == "init.lua" || part == "init.luau" {
-                    return None;
-                }
+				if part == "init.lua" || part == "init.luau" {
+					return None;
+				}
 
-                let displayed =
-                    if next_ct.is_some() {
-                        &part
-                    } else {
-                        part.strip_suffix(".luau")
-                            .or_else(|| part.strip_suffix(".lua"))
-                            .unwrap_or(&*part)
-                    }
-                    .to_string();
+				let displayed =
+					if next_ct.is_some() {
+						&part
+					} else {
+						part.strip_suffix(".luau")
+							.or_else(|| part.strip_suffix(".lua"))
+							.unwrap_or(&*part)
+					}
+					.to_string();
 
-                Some(displayed)
-            }
+				Some(displayed)
+			}
 			_ => None,
 		})
 		.collect::<Vec<_>>()


### PR DESCRIPTION
Fixes #47 