### PR TITLE
Provide Nix flake, package and shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build_rs_cov.profraw
 registry/data
 data
 manifest.schema.json
+/.direnv
+**/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  flakeCompat = fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  };
+  pesde = import flakeCompat {
+    src = ./.;
+  };
+in
+  pesde.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "path": "/nix/store/01x5k4nlxcpyd85nnr0b9gm89rm8ff4x-source",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "path"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "pesde; A package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune";
+  inputs = {
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    flake-utils,
+    nixpkgs,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system: let
+      treefmtEval = inputs.treefmt-nix.lib.evalModule inputs.nixpkgs.legacyPackages.${system} ./treefmt.nix;
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.default = import ./nix/shell.nix {inherit pkgs;};
+
+      packages = let
+        pesde = pkgs.callPackage ./nix/package.nix {};
+      in {
+        inherit pesde;
+        default = pesde;
+      };
+    });
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  dbus,
+}:
+rustPlatform.buildRustPackage (_finalAttrs: {
+  pname = "pesde";
+  version = "0.7.1";
+
+  src = ../.;
+
+  cargoHash = "sha256-7rEU4vU6qp6eaj777cC3BgrRyiLRe+5xZC+cqV5TTc4=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "bin"
+    "version-management"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    openssl
+    dbus
+  ];
+
+  meta = {
+    mainProgram = "pesde";
+    description = "A package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune";
+    homepage = "https://github.com/pesde-pkg/pesde";
+    license = lib.licenses.mit;
+    maintainers = [];
+  };
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,14 @@
+{pkgs ? import <nixpkgs> {}, ...}: pkgs.mkShell {
+  packages = with pkgs; [
+    pkg-config
+    openssl
+    dbus
+    cargo
+    rustc
+    clippy
+    rust-analyzer
+    (rustfmt.override {
+      asNightly = true;
+    })
+  ];
+}


### PR DESCRIPTION
Hi! This adds several things for [NixOS](https://nixos.org/) and [Nix](https://nix.dev/manual/nix/2.28/) users to this project.

I can make a separate repository (presumably I would name it something like pesde-flake) to maintain these additions separately, if you should wish instead of incorporating them into your 0.7 branch.

I may also contemplate upstreaming this directly to [nixpkgs](https://github.com/NixOS/nixpkgs/) and becoming its maintainer separately aside from the project itself, to provide this package manager for all nixpkgs users.

## Usage

* to build package with Nix: `nix build .#` or `nix build .#pesde`
* to obtain shell automagically (.envrc provided): use [direnv](https://direnv.net/) and run `direnv allow` to be dropped into a shell automatically
* manual shell obtainment: `nix develop`, `nix develop .#`

## Maintenance

When you change the contents of your Cargo.toml or the Cargo.lock lockfile changes, `nix/package.nix` will require updating thusly; there is a `cargoHash`, e.g.
```
  cargoHash = "sha256-7rEU4vU6qp6eaj777cC3BgrRyiLRe+5xZC+cqV5TTc4=";
```
Replace the hash with "" and `nix build .#` to get the new hash that should be provided where the old one was.
The version within `nix/package.nix` must also be incremented alongside the repository changes.