### PR TITLE
fix: resolve local path dependencies from their package roots

### DIFF
--- a/src/source/git/mod.rs
+++ b/src/source/git/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 use fs_err::tokio as fs;
 use gix::{bstr::BStr, traverse::tree::Recorder, ObjectId, Url};
 use relative_path::RelativePathBuf;
+use semver::{BuildMetadata, Version};
 use std::{
 	collections::{BTreeMap, BTreeSet},
 	fmt::Debug,
@@ -234,6 +235,13 @@ impl PackageSource for GitPackageSource {
 			} else {
 				root_tree.clone()
 			};
+			let version = Version {
+				major: 0,
+				minor: 0,
+				patch: 0,
+				build: BuildMetadata::EMPTY,
+				pre: tree.id.to_string().parse().unwrap(),
+			};
 
 			let manifest = match read_file(&tree, [MANIFEST_FILE_NAME])
 				.map_err(|e| errors::ResolveError::ReadManifest(Box::new(repo_url.clone()), e))?
@@ -285,7 +293,7 @@ impl PackageSource for GitPackageSource {
 				return Ok((
 					PackageNames::Wally(manifest.package.name),
 					VersionId(
-						manifest.package.version,
+						version,
 						match manifest.package.realm {
 							Realm::Shared => TargetKind::Roblox,
 							Realm::Server => TargetKind::RobloxServer,
@@ -306,7 +314,7 @@ impl PackageSource for GitPackageSource {
 
 			Ok((
 				PackageNames::Pesde(manifest.name),
-				VersionId(manifest.version, manifest.target.kind()),
+				VersionId(version, manifest.target.kind()),
 				dependencies,
 				tree.id.to_string(),
 			))

--- a/src/source/path/mod.rs
+++ b/src/source/path/mod.rs
@@ -13,14 +13,24 @@ use crate::{
 	},
 	Project,
 };
+use fs_err::tokio as fs;
 use futures::TryStreamExt as _;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
 use tracing::instrument;
 
 /// The path package reference
 pub mod pkg_ref;
 /// The path dependency specifier
 pub mod specifier;
+
+fn resolve_path_from(base_dir: &Path, path: &Path) -> PathBuf {
+	if path.is_relative() {
+		base_dir.join(path)
+	} else {
+		path.to_path_buf()
+	}
+}
 
 /// The path package source
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -42,9 +52,12 @@ impl PackageSource for PathPackageSource {
 	) -> Result<ResolveResult<Self::Ref>, Self::ResolveError> {
 		let ResolveOptions { project, .. } = options;
 
-		let manifest = deser_manifest(&specifier.path).await?;
+		let path = fs::canonicalize(resolve_path_from(project.package_dir(), &specifier.path))
+			.await
+			.map_err(crate::errors::ManifestReadError::Io)?;
+		let manifest = deser_manifest(&path).await?;
 
-		let (path_package_dir, path_workspace_dir) = find_roots(specifier.path.clone()).await?;
+		let (path_package_dir, path_workspace_dir) = find_roots(path.clone()).await?;
 		let path_project = Project::new(
 			path_package_dir,
 			path_workspace_dir,
@@ -63,6 +76,7 @@ impl PackageSource for PathPackageSource {
 
 		let pkg_ref = PathPackageRef {
 			path: specifier.path.clone(),
+			absolute_path: path.clone(),
 			dependencies: manifest
 				.all_dependencies()?
 				.into_iter()
@@ -108,7 +122,9 @@ impl PackageSource for PathPackageSource {
 								)?,
 							});
 						}
-						DependencySpecifiers::Path(_) => {}
+						DependencySpecifiers::Path(specifier) => {
+							specifier.path = resolve_path_from(&path, &specifier.path);
+						}
 					}
 
 					Ok((alias, (spec, ty)))
@@ -133,14 +149,16 @@ impl PackageSource for PathPackageSource {
 		options: &DownloadOptions<R>,
 	) -> Result<PackageFs, Self::DownloadError> {
 		let DownloadOptions { reporter, .. } = options;
-		let manifest = deser_manifest(&pkg_ref.path).await?;
+		let path = if pkg_ref.absolute_path.as_os_str().is_empty() {
+			&pkg_ref.path
+		} else {
+			&pkg_ref.absolute_path
+		};
+		let manifest = deser_manifest(path).await?;
 
 		reporter.report_done();
 
-		Ok(PackageFs::Copy(
-			pkg_ref.path.clone(),
-			manifest.target.kind(),
-		))
+		Ok(PackageFs::Copy(path.to_path_buf(), manifest.target.kind()))
 	}
 
 	#[instrument(skip_all, level = "debug")]
@@ -149,7 +167,12 @@ impl PackageSource for PathPackageSource {
 		pkg_ref: &Self::Ref,
 		_options: &GetTargetOptions,
 	) -> Result<Target, Self::GetTargetError> {
-		let manifest = deser_manifest(&pkg_ref.path).await?;
+		let path = if pkg_ref.absolute_path.as_os_str().is_empty() {
+			&pkg_ref.path
+		} else {
+			&pkg_ref.absolute_path
+		};
+		let manifest = deser_manifest(path).await?;
 
 		Ok(manifest.target)
 	}

--- a/src/source/path/pkg_ref.rs
+++ b/src/source/path/pkg_ref.rs
@@ -10,6 +10,9 @@ use std::{collections::BTreeMap, path::PathBuf};
 pub struct PathPackageRef {
 	/// The path of the package
 	pub path: PathBuf,
+	/// The absolute path of the package for filesystem operations
+	#[serde(skip, default)]
+	pub absolute_path: PathBuf,
 	/// The dependencies of the package
 	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
 	pub dependencies: BTreeMap<Alias, (DependencySpecifiers, DependencyType)>,


### PR DESCRIPTION
## Summary

Fix local `path` dependency resolution so relative paths are resolved from the package that declares them.

This also ensures nested relative `path` dependencies inside resolved path packages are interpreted from that package's root, instead of depending on the caller's current project root.

## Problem

Relative local dependencies could be resolved from the wrong root during dependency graph construction.

That could break workspace member dependencies like:

```toml
[dependencies]
SomePackage = { path = "../SomePackage" }
```

and also affect nested local `path` dependencies inside path packages.

## Changes

- resolve incoming local `path` dependencies relative to `ResolveOptions.project.package_dir()`
- use that resolved absolute path for manifest reads, root discovery, download, and target reads
- rebase nested relative `path` dependencies from the resolved path package root
- keep the original manifest path while storing the resolved absolute path for filesystem operations

This was prepared against the `0.7` branch because the issue was reproduced there.