### PR TITLE
chore: fix docs typo in self-hosting-registries

### DIFF
--- a/docs/src/content/docs/guides/self-hosting-registries.mdx
+++ b/docs/src/content/docs/guides/self-hosting-registries.mdx
@@ -215,7 +215,7 @@ cargo build --release -p pesde-registry
 This will build the registry. The resulting binary will be located at
 `target/release/pesde-registry` or `target/release/pesde-registry.exe`.
 
-After setting the environment variables, you can run the registry using the
+After setting the environment variables, you can run the registry
 by executing the binary.
 
 The registry must be exposed at the URL specified in the `api` field of the


### PR DESCRIPTION
Fixes a small typo in the self-hosting-registries docs