### PR TITLE
refactor: shorten package directory names

### DIFF
--- a/src/linking/incremental.rs
+++ b/src/linking/incremental.rs
@@ -4,7 +4,6 @@ use crate::Project;
 use crate::graph::DependencyGraph;
 use crate::source::Realm;
 use crate::source::RealmExt as _;
-use crate::util::ToEscaped as _;
 use crate::util::remove_empty_dir;
 use fs_err::tokio as fs;
 use std::collections::HashSet;
@@ -49,7 +48,7 @@ impl Project {
 
 				while let Some(pkg_id) = queue.pop() {
 					if let Some(node) = graph.nodes.get(pkg_id)
-						&& expected_ids.insert(pkg_id.to_string().escaped())
+						&& expected_ids.insert(pkg_id.escaped())
 					{
 						for dep in node.dependencies.values() {
 							queue.push(&dep.id);

--- a/src/linking/mod.rs
+++ b/src/linking/mod.rs
@@ -25,7 +25,7 @@ impl DependencyGraphNode {
 	/// Returns the directory to store the contents of the package in, e.g. foo+1.0.0/1.0.0
 	#[must_use]
 	pub fn container_dir(package_id: &PackageId, structure_kind: &StructureKind) -> PathBuf {
-		let base = PathBuf::from(package_id.to_string().escaped());
+		let base = PathBuf::from(package_id.escaped());
 
 		match structure_kind {
 			StructureKind::Wally(name) => base.join(&**name),

--- a/src/source/ids.rs
+++ b/src/source/ids.rs
@@ -6,6 +6,7 @@ use crate::source::errors::PackageRefParseError;
 use crate::source::errors::PackageSourcesFromStr;
 use crate::source::path::PathPackageSource;
 use crate::source::path::local_version;
+use crate::util::ToEscaped as _;
 use semver::Version;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -39,6 +40,12 @@ impl PackageId {
 	#[must_use]
 	pub fn version(&self) -> &Version {
 		&self.0.2
+	}
+
+	/// Returns this package ID as a string that can be used in the filesystem
+	#[must_use]
+	pub fn escaped(&self) -> String {
+		self.to_string().replacen("https://", "", 1).escaped()
 	}
 }
 
@@ -164,5 +171,17 @@ mod tests {
 			let id: PackageId = serialized.parse().unwrap();
 			assert_eq!(id.to_string(), serialized);
 		}
+	}
+
+	#[test]
+	fn escaped_package_ids() {
+		let id = "wally:https://github.com/pesde-pkg/index:foo/bar@1.2.3"
+			.parse::<PackageId>()
+			.unwrap();
+
+		assert_eq!(
+			id.escaped(),
+			"wally-github.com-pesde-pkg-index-foo-bar-1.2.3"
+		);
 	}
 }


### PR DESCRIPTION
- omit `https://` from escaped package directory names
- use the shortened ID for linking and incremental cleanup
- `wally-https---github.com-...` → `wally-github.com-...`