### PR TITLE
fix: inherit environment variables in scripts

### DIFF
--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -44,21 +44,17 @@ pub async fn execute_script<H: ExecuteScriptHooks>(
 	let parsed_script = croshet::parser::parse(script)?;
 
 	let (stdout, stderr, stdin) = hooks.stdio();
+	let mut options = croshet::ExecuteOptionsBuilder::new()
+		.cwd(subproject.dir())
+		.stdout(stdout)
+		.stderr(stderr)
+		.stdin(stdin)
+		.args(args)
+		.build()
+		.unwrap();
+	options.env_vars = std::env::vars_os().collect();
 
-	let (code, stdio_result) = tokio::join!(
-		croshet::execute(
-			parsed_script,
-			croshet::ExecuteOptionsBuilder::new()
-				.cwd(subproject.dir())
-				.stdout(stdout)
-				.stderr(stderr)
-				.stdin(stdin)
-				.args(args)
-				.build()
-				.unwrap(),
-		),
-		hooks.run(),
-	);
+	let (code, stdio_result) = tokio::join!(croshet::execute(parsed_script, options), hooks.run(),);
 	stdio_result.map_err(errors::ExecuteScriptError::Hooks)?;
 
 	Ok(code)

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -54,7 +54,7 @@ pub async fn execute_script<H: ExecuteScriptHooks>(
 		.unwrap();
 	options.env_vars = std::env::vars_os().collect();
 
-	let (code, stdio_result) = tokio::join!(croshet::execute(parsed_script, options), hooks.run(),);
+	let (code, stdio_result) = tokio::join!(croshet::execute(parsed_script, options), hooks.run());
 	stdio_result.map_err(errors::ExecuteScriptError::Hooks)?;
 
 	Ok(code)


### PR DESCRIPTION
- pass the parent process environment to scripts executed through croshet
- assign environment variables directly to the built `ExecuteOptions`